### PR TITLE
new: do not raise from Exists method + use same parameters for resolve parent

### DIFF
--- a/uiautomation/uiautomation.py
+++ b/uiautomation/uiautomation.py
@@ -2434,9 +2434,11 @@ class Control(LegacyIAccessiblePattern, QTPLikeSyntaxSupport):
         if self._element:
             _AutomationClient.instance().dll.ReleaseElement(self._element)
         self._element = 0
-        if self.searchFromControl:
-            self.searchFromControl.Element # search searchFromControl first before timing
         start = time.clock()
+        # Use same timeout(s) parameters for resolve all parents
+        prev =  self.searchFromControl
+        if prev and not prev._element and not prev.Exists(maxSearchSeconds, searchIntervalSeconds):
+            return False
         while True:
             control = FindControl(self.searchFromControl, self._CompareFunction, self.searchDepth, False, self.foundIndex)
             if control:


### PR DESCRIPTION
* do not raise from Exists method
* use same parameters (timeouts) for resolve parent. 

For example I have TIME_OUT_SECOND == 1 but run Control.Exists with maxSearchSeconds == 5. In this case uiautomation try find parent (searchFromControl) for 1 seconds and if not - raise LookupError, because Control.Element property use Refind.

