### PR TITLE
fix: exception "KeyError: 0 in ControlTypeName"

### DIFF
--- a/uiautomation/uiautomation.py
+++ b/uiautomation/uiautomation.py
@@ -2578,7 +2578,7 @@ class Control(LegacyIAccessiblePattern, QTPLikeSyntaxSupport):
     @property
     def ControlTypeName(self):
         """Return str ControlTypeName"""
-        return ControlTypeNameDict[self.ControlType]
+        return ControlTypeNameDict.get(self.ControlType, 'UnknownControl')
 
     @property
     def LocalizedControlType(self):


### PR DESCRIPTION
Fix exception
```
  File "site-packages\uiautomation\uiautomation.py", line 2581, in ControlTypeName
KeyError: 0
```
what sometimes occurs in automation.py use.