### PR TITLE
new: add falg CHECK_SEARCH_PROPERTY_NAME to disable property's name check

### DIFF
--- a/uiautomation/uiautomation.py
+++ b/uiautomation/uiautomation.py
@@ -31,6 +31,7 @@ MAX_MOVE_SECOND = 1  # simulate mouse move or drag max seconds
 TIME_OUT_SECOND = 15
 OPERATION_WAIT_TIME = 0.5
 MAX_PATH = 260
+CHECK_SEARCH_PROPERTY_NAME = True
 
 
 class _AutomationClient:
@@ -2483,7 +2484,7 @@ class Control(LegacyIAccessiblePattern, QTPLikeSyntaxSupport):
             elif 'Compare' == key:
                 if not value(control, depth):
                     return False
-            else:
+            elif CHECK_SEARCH_PROPERTY_NAME:
                 raise KeyError('unsupported argument: {} in {} constructor'.format(key, self.__class__.__name__))
         return True
 


### PR DESCRIPTION
We start using your great library python uiautomation for test GUI of our small product. For test purpose I add additional custom properties to "search properties". For example in next code
```
owner.CustomControl(Name='sync_dlg', HumanDesc='"Sync create" panel')
```
i added custom property HumanDesc. It not used in search, but used when errors occured:
```
LookupError: can't find "Sync create" panel in "SYNC" pane
  WindowControl(Name='console')                               Program main window
   PaneControl(Name='')                                       "SYNC" pane
    CustomControl(Name='sync_dialog_first_sync')              "Sync create" panel
```

So I use search property as metadata holder.

This works fine, until this change arrived to project repo (needed line highlighted):

https://github.com/yinkaisheng/Python-UIAutomation-for-Windows/commit/f878e7feac22f993424e5b84cc7c8dc89c8a9db6#diff-947fa8193f98150b44ae77b719124fe0R2426 

You added code to check property's name, so our logic was broken. I write some patch for introduce const to disable this check