### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 from setuptools import find_packages, setup
+import sys
 
 from uiautomation import VERSION, AUTHOR_MAIL
+
+
+requires = ['comtypes>=1.1.7',]
+if sys.version_info < (3, 5):
+    requires.append('typing')
 
 setup(
     name='uiautomation',
@@ -25,8 +31,5 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    install_requires=[
-        'typing',
-        'comtypes>=1.1.7',
-        ]
+    install_requires=requires
 )


### PR DESCRIPTION
大于python3.5版本时不去自动安装typing模块。