### PR TITLE
fix GetEditText TypeError

### DIFF
--- a/uiautomation/uiautomation.py
+++ b/uiautomation/uiautomation.py
@@ -2364,7 +2364,7 @@ def GetEditText(handle: int) -> str:
     textLen = SendMessage(handle, 0x000E, 0, 0) + 1  # WM_GETTEXTLENGTH
     arrayType = ctypes.c_wchar * textLen
     values = arrayType()
-    SendMessage(handle, 0x000D, textLen, values)  # WM_GETTEXT
+    SendMessage(handle, 0x000D, textLen, ctypes.addressof(values))  # WM_GETTEXT
     return values.value
 
 


### PR DESCRIPTION
arrayType 无法直接传递给 SendMessage 的 int 类型参数