### PR TITLE
Fix control bitmap bounds with DWM enabled

### DIFF
--- a/uiautomation/uiautomation.py
+++ b/uiautomation/uiautomation.py
@@ -3517,6 +3517,10 @@ class Bitmap:
             handle = control.NativeWindowHandle
             if handle:
                 pRect = control.BoundingRectangle
+                toplevelHandle = GetAncestor(handle, GAFlag.Root)
+                if toplevelHandle and toplevelHandle == handle:
+                    if DwmIsCompositionEnabled():
+                        pRect = DwmGetWindowExtendFrameBounds(handle) or pRect
                 left = rect.left - pRect.left + x
                 top = rect.top - pRect.top + y
                 right = left + width


### PR DESCRIPTION
The PR #307 introduced a regression while creating a Bitmap object from a Control. This PR partially resolved #308, but only for a window control. When transforming an inner control into a Bitmap, the current code is computing `pRect` which is the bounding rectangle of the handle and add its coordinates to the requested rectangle's ones.

I had an issue because the bounding rectangle of my window start from `(-8, -8)` and goes to `(1928, 1088)`, and all my screenshots were dephased from 8 pixels to the top and to the left. Replacing theses boundings with these given by `DwmGetWindowExtendFrameBounds` solves the issue, as in other parts of the file.